### PR TITLE
Call HTTPS instead of HTTP

### DIFF
--- a/JoomagREST.php
+++ b/JoomagREST.php
@@ -4,7 +4,7 @@
  * Class JoomagREST
  */
 class JoomagREST {
-    const BASE_URL = "http://www.joomag.com/api/2.0/";
+    const BASE_URL = "https://www.joomag.com/api/2.0/";
 
     const CAT_GENERAL = 6;
     const CAT_PRO_SPORTS = 7;


### PR DESCRIPTION
Joomag API 2.0 seem to be schemaless, so you can make https call instead of http. We had some problem last day because it was generating some active mixed-content, the problem has been reported to the support and resolved, but anyway I just wanted to inform about that.